### PR TITLE
fix: infinite loop when no arguments

### DIFF
--- a/src/clout/_loaders/parsing.py
+++ b/src/clout/_loaders/parsing.py
@@ -336,6 +336,8 @@ def find_missing_input(parser, s: str) -> t.Optional[t.List[str]]:
         return None
 
     while True:
+        if not words:
+            return None
         try:
             parser.parse(subprocess.list2cmdline(words[:-1]))
         except lark.exceptions.ParseError:
@@ -364,9 +366,12 @@ class Parser:
         parser = lark.Lark(grammar, parser="earley", ambiguity="explicit")
         try:
             tree = parser.parse(s)
+
         except lark.exceptions.ParseError as e:
             found = find_missing_input(parser, s)
-            raise clout.exceptions.MissingInput(self.group, s, found) from e
+            if found:
+                raise clout.exceptions.MissingInput(self.group, s, found) from e
+            raise lark.exceptions.ParseError()
 
         try:
             tree = RemoveInvalidBranches(group=self.group).transform(tree)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,6 +70,17 @@ def test_show_missing_data_args():
     assert "Missing data for required field" in proc.stderr.decode()
 
 
+def test_no_args():
+    """When no arguments are provided, explain the problem to the user."""
+    proc = subprocess.run(
+        [sys.executable, "docs/short.py"], capture_output=True, check=False, timeout=5
+    )
+    assert proc.returncode == 1, proc.stderr.decode()
+
+    output = proc.stdout.decode()
+    assert output.startswith("Usage:")
+
+
 def test_envvar():
     """``envvar=`` metadata argument defines the environment variable for a field."""
     args = ["--age", "21"]


### PR DESCRIPTION
I implemented a test that reproduces the error I experienced in #23 and worked from there;
There was an infinite loop in the `found_missing_input(parser, s)` when the `words` variable is empty.
The function now returns None under these conditions, and the `parse_string` method returns a generic `ParseError` so that it can be handled by the caller.

fixes #23